### PR TITLE
updating cosmodb example to work with dotnet core 3.1

### DIFF
--- a/dotnet/LensesApp.csproj
+++ b/dotnet/LensesApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/LensesApp.csproj
+++ b/dotnet/LensesApp.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <None Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0" />
+    <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.Storage.Common" Version="9.4.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />


### PR DESCRIPTION
current examples were designed for dotnet 2.1 which is not available on azure cloud shell